### PR TITLE
Improve rotation consistency across devices

### DIFF
--- a/src/UniverseGroup.js
+++ b/src/UniverseGroup.js
@@ -9,6 +9,7 @@ import Text from './Text.js';
 import Space from "./Space.js";
 
 extend({ TextGeometry })
+const ROTATION_SPEED = .05;
 
 export default function UniverseGroup(props) {
   const { camPosition, cameraRef } = props;
@@ -17,10 +18,9 @@ export default function UniverseGroup(props) {
   const spaceMesh = React.useRef();
   const textMesh = React.useRef();
 
-  //TODO: Update to be dependent on clock for speed instead of FPS
   useFrame(({ clock }) => {
     if (spaceMesh.current) {
-      spaceMesh.current.rotation.y += .0005;
+      spaceMesh.current.rotation.y = clock.getElapsedTime() * ROTATION_SPEED;
       spaceMesh.current.position.set(0, 0, 0);
     }
   })


### PR DESCRIPTION
Rotation was based on frame count, which worked well at around 100fps, giving it about 0.05 radians per second. But this approach caused slower rotation speeds on mobile devices with lower frame rates.

This change now has the galaxy rotating at a consistent 0.05 radians per second, making it rotate just under half a full rotation per minute on all devices.